### PR TITLE
팀 확인 로직에 캐싱을 적용한다

### DIFF
--- a/src/main/java/com/woowacourse/integratedbot/configuration/CacheConfiguration.java
+++ b/src/main/java/com/woowacourse/integratedbot/configuration/CacheConfiguration.java
@@ -1,0 +1,19 @@
+package com.woowacourse.integratedbot.configuration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfiguration {
+
+    private static final String WOOWACOURSE_TEAM_CACHE_NAME = "woowacourseTeam";
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager(WOOWACOURSE_TEAM_CACHE_NAME);
+    }
+}

--- a/src/main/java/com/woowacourse/integratedbot/domain/WoowacourseTeamJdbcRepository.java
+++ b/src/main/java/com/woowacourse/integratedbot/domain/WoowacourseTeamJdbcRepository.java
@@ -1,6 +1,7 @@
 package com.woowacourse.integratedbot.domain;
 
 import java.util.Optional;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
@@ -20,6 +21,7 @@ public class WoowacourseTeamJdbcRepository implements WoowacourseTeamRepository 
     }
 
     @Override
+    @Cacheable(value = "woowacourseTeam", unless="#result == null")
     public Optional<WoowacourseTeam> findByCode(final String code) {
         String sql = "SELECT * FROM woowacourse_team where code = ?";
         return jdbcTemplate.query(sql, woowcourseTeamRowMapper(), code)


### PR DESCRIPTION
spring에서 기본적으로 제공하는 `@Cacheable`을 사용하였습니다. (기본적인 동작은 AOP입니다.)

다른 Cacha Manager 구현체를 사용하고싶다면 dependency를 추가하여야 사용가능하며 기본적으로는 `ConcurrentHashMap`으로 구현된 `ConcurrentMapCacheManager`을 제공하기에 따로 추가하지는 않았습니다.

`@Cacheable`는 캐시값이 없는 경우 로직 수행 후 캐시 데이터를 추가하며, 캐시 데이터가 있으면 해당 데이터를 반환합니다. 이때 결과값이 없다면 굳이 캐싱될 필요가 없으므로 캐싱 대상에서 제외해두었습니다.(`#result == null`)

더 추가적인 옵션은 현재 팀 코드를 관리하는 코드가 없기때문에 추가할 필요성이 따로 없어보인다만 어드민 api를 몇개 추가하여 팀 코드를 관리하게 된다면 `@CacheEvict`를 사용하여 제거하는 방향으로 가면 될 것 같네요.

https://docs.spring.io/spring-framework/docs/4.3.6.RELEASE/spring-framework-reference/html/cache.html